### PR TITLE
(FIX) Correct release notes URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,16 @@ jobs:
       - uses: goreleaser/goreleaser-action@v4
         with:
           install-only: true
-      - run: |
+      - name: Build and Test
+        run: |
           ./build.ps1 -Target Test -ErrorAction Stop
+      - name: Show `version` output
+        run: |
+          $fizztool = Get-Command "./dist/fizztool*/fizztool*" -ErrorAction Stop
+          & $fizztool version
+          & $fizztool version | ConvertFrom-Json
+      - name: Show `get` output
+        run: |
+          $fizztool = Get-Command "./dist/fizztool*/fizztool*" -ErrorAction Stop
+          & $fizztool get --key fizz
+          & $fizztool get --key fizz | ConvertFrom-Json

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -305,7 +305,7 @@ func getReleaseNotesURL(version string) string {
 	}
 
 	url := fmt.Sprintf(
-		"%s/releases/tag/%s",
+		"%s/releases/tag/v%s",
 		base_url,
 		strings.TrimPrefix(version, "v"),
 	)


### PR DESCRIPTION
Prior to this change, the release notes URL did not include the leading `v` for the tag, breaking the URL. This change adds it in.